### PR TITLE
Use `Cloud#getUrl` in /provision URL

### DIFF
--- a/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloud/computerSet.jelly
+++ b/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloud/computerSet.jelly
@@ -4,7 +4,7 @@
     <tr>
       <td />
       <td colspan="${monitors.size()+1}">
-        <f:form action="${rootURL}/cloud/${it.name}/provisionArguments" method="post" name="provisionArguments">
+        <f:form action="${rootURL}/${it.url}/provisionArguments" method="post" name="provisionArguments">
 
           <input type="submit" class="compute-provision-button" value="${%provision(it.displayName)}" />
 


### PR DESCRIPTION
Follow up of https://github.com/jenkinsci/jenkins/pull/7573.

This has no effect on older versions of Jenkins. On newer versions of Jenkins this prevents a bug that I've briefly described in the PR linked above.