### PR TITLE
Exclude jersey inside OCI SDK as it will conflict with any plugin that uses jersey2 (Artifactory plugin, Gitlab plugin), use jersey2-api plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ View OCI Compute Plugin page on the [plugins.jenkins.io](https://plugins.jenkins
 
 2. Jenkins installed with JDK 8 or higher.
 
-3. Required Plugins: [bouncycastle API](https://plugins.jenkins.io/bouncycastle-api), [SSH Credentials](https://plugins.jenkins.io/ssh-credentials/), and [Credentials](https://plugins.jenkins.io/credentials)
+3. Required Plugins: [bouncycastle API](https://plugins.jenkins.io/bouncycastle-api), [SSH Credentials](https://plugins.jenkins.io/ssh-credentials/), [Credentials](https://plugins.jenkins.io/credentials)  and [Jersey2 API](https://plugins.jenkins.io/jersey2-api)
 
 
 
 ## Compatibility
-Minimum Jenkins requirement: ***2.222.4***
+Minimum Jenkins requirement: ***2.263.1***
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <java.level>8</java.level>
     <oci-java-sdk.version>2.27.0</oci-java-sdk.version>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.263.1</jenkins.version>
     <enforcer.skip>true</enforcer.skip>
   </properties>
 
@@ -104,6 +104,28 @@
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
       <version>${oci-java-sdk.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.client</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.connectors</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
@@ -119,6 +141,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
       <version>2.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jersey2-api</artifactId>
+      <version>2.35-8</version>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>


### PR DESCRIPTION
Inlcuding jersey libraries inside WEB-INF/lib causes conflicts if any other plugin uses jersey. The most likely result is this plugin will not work, unless jersey-hk2 from a different plugin is copied in at the same version.

Solution is to use jersey2-api jenkins plugin, which other plugins use. 

### Testing done

Ran `mvn clean test`, loaded plugin into my own instance and created instances with it.
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch! (fork)
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (I can make a JIRA if requested.)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (effectively that the tests work *is* the test, as it has to compile against the jersey libraries provided by jersey2-api, not its own ones.)

