### PR TITLE
feat: Add maxTotalUses support to agent templates

### DIFF
--- a/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgent.java
+++ b/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgent.java
@@ -40,10 +40,6 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
 
     private static RetentionStrategy<? extends Computer> createRetentionStrategy(String idleTerminationMinutes) {
         int idleMinutes = idleTerminationMinutes == null || idleTerminationMinutes.trim().isEmpty() ? 0 : Integer.parseInt(idleTerminationMinutes);
-
-        if (idleMinutes == 0) {
-            return new RetentionStrategy.Always();
-        }
         return new BaremetalCloudRetentionStrategy(idleMinutes);
     }
 
@@ -56,6 +52,7 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
     public final int templateId;
     public boolean verificationStrategy;
     private String hostip="";
+    public int maxTotalUses;
 
     public BaremetalCloudAgent(final String name,
             final BaremetalCloudAgentTemplate template,
@@ -84,7 +81,8 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
                 template.getInitScriptEnvVarsVersion(),
                 template.getInitScriptTimeoutSeconds(),
                 host,
-                template.getTemplateId());
+                template.getTemplateId(),
+                template.getMaxTotalUses());
     }
 
     @DataBoundConstructor
@@ -109,7 +107,8 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
             final String initScript,
             final int initScriptTimeoutSeconds,
             final String host,
-            final int templateId) throws IOException, FormException{
+            final int templateId,
+            final int maxTotalUses) throws IOException, FormException{
     	super(name,
                 description,
                 remoteFS,
@@ -137,6 +136,7 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
         this.customJVMOpts = customJVMOpts;
         this.verificationStrategy = verificationStrategy;
         this.hostip = host;
+        this.maxTotalUses = maxTotalUses;
     }
 
     private BaremetalCloudAgent(final String name,
@@ -155,7 +155,8 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
             final String initScript,
             final ComputerLauncher computerLauncher,
             final RetentionStrategy retentionStrategy,
-            final int templateId) throws IOException,
+            final int templateId,
+            final int maxTotalUses) throws IOException,
             FormException {
         super(name, description, remoteFS, numExecutors, mode, labelString, computerLauncher, retentionStrategy,
                 nodeProperties);
@@ -167,6 +168,7 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
         this.verificationStrategy = verificationStrategy;
         this.initScript = initScript;
         this.templateId = templateId;
+        this.maxTotalUses = maxTotalUses;
     }
 
     public String getJenkinsAgentUser() {
@@ -307,7 +309,8 @@ public class BaremetalCloudAgent extends AbstractCloudSlave{
                     initScript,
                     getLauncher(),
                     getRetentionStrategy(),
-                    templateId);
+                    templateId,
+                    maxTotalUses);
         } catch (FormException | IOException e) {
             LOGGER.warning("Failed to reconfigure BareMetalAgent: " + name);
         }

--- a/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate.java
+++ b/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate.java
@@ -101,6 +101,7 @@ public class BaremetalCloudAgentTemplate implements Describable<BaremetalCloudAg
     public final String retryTimeoutMins;
     private long bootVolumeVPUs;
     public final Boolean disableLegacyImdsEndpoint;
+    public final int maxTotalUses;
 
     private transient int failureCount=0;
     private transient String disableCause;
@@ -146,7 +147,8 @@ public class BaremetalCloudAgentTemplate implements Describable<BaremetalCloudAg
             final String memoryInGBs,
             final Boolean doNotDisable,
             final String retryTimeoutMins,
-            final Boolean disableLegacyImdsEndpoint){
+            final Boolean disableLegacyImdsEndpoint,
+            final int maxTotalUses){
     	this.compartmentId = compartmentId;
         this.availableDomain = availableDomain;
         this.vcnCompartmentId = vcnCompartmentId;
@@ -186,6 +188,7 @@ public class BaremetalCloudAgentTemplate implements Describable<BaremetalCloudAg
         this.retryTimeoutMins = retryTimeoutMins;
         this.verificationStrategy = verificationStrategy;
         this.disableLegacyImdsEndpoint = disableLegacyImdsEndpoint;
+        this.maxTotalUses = maxTotalUses;
     }
 
     public String getCompartmentId() {
@@ -418,6 +421,10 @@ public class BaremetalCloudAgentTemplate implements Describable<BaremetalCloudAg
 
     public Boolean getDisableLegacyImdsEndpoint() {
         return disableLegacyImdsEndpoint;
+    }
+
+    public int getMaxTotalUses() {
+        return maxTotalUses;
     }
 
     @Override

--- a/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudRetentionStrategy.java
+++ b/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudRetentionStrategy.java
@@ -1,23 +1,31 @@
 package com.oracle.cloud.baremetal.jenkins;
 
+import java.io.IOException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import hudson.model.Executor;
+import hudson.model.ExecutorListener;
+import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.OfflineCause.SimpleOfflineCause;
 
-public class BaremetalCloudRetentionStrategy extends CloudRetentionStrategy {
+public class BaremetalCloudRetentionStrategy extends CloudRetentionStrategy implements ExecutorListener {
     private static final Logger LOGGER = Logger.getLogger(BaremetalCloud.class.getName());
+    private final int idleMinutes;
 
     public BaremetalCloudRetentionStrategy(int idleMinutes) {
-        super(idleMinutes);
+        super(idleMinutes > 0 ? idleMinutes : Integer.MAX_VALUE);
+        this.idleMinutes = idleMinutes;
     }
 
     /**
      * Prevent {@link CloudRetentionStrategy} from terminating the Computer if it is
      * in offline state set by user (e.g. from Web UI) or by another plugin.
+     * Also prevent idle termination when idleMinutes is 0 (keep-forever mode).
      */
     @Override
     @GuardedBy("hudson.model.Queue.lock")
@@ -26,7 +34,51 @@ public class BaremetalCloudRetentionStrategy extends CloudRetentionStrategy {
             LOGGER.fine(c.getDisplayName() + ": Node is set temporarily offline - will not terminate");
             return 1;
         }
-
+        if (idleMinutes == 0) {
+            return 1;
+        }
         return super.check(c);
+    }
+
+    @Override
+    public void taskAccepted(Executor executor, Queue.Task task) {
+        BaremetalCloudComputer computer = (BaremetalCloudComputer) executor.getOwner();
+        if (computer == null) return;
+        BaremetalCloudAgent agent = computer.getNode();
+        if (agent != null) {
+            int maxTotalUses = agent.maxTotalUses;
+            if (maxTotalUses <= 0) {
+                LOGGER.fine("maxTotalUses set to unlimited (" + maxTotalUses + ") for agent " + agent.getInstanceId());
+            } else if (maxTotalUses == 1) {
+                LOGGER.info("maxTotalUses drained - suspending agent " + agent.getInstanceId());
+                computer.setAcceptingTasks(false);
+            } else {
+                agent.maxTotalUses = maxTotalUses - 1;
+                LOGGER.info("Agent " + agent.getInstanceId() + " has " + agent.maxTotalUses + " builds left");
+            }
+        }
+    }
+
+    @Override
+    public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
+        taskCompletedWithProblems(executor, task, durationMS, null);
+    }
+
+    @Override
+    public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
+        BaremetalCloudComputer computer = (BaremetalCloudComputer) executor.getOwner();
+        if (computer == null) return;
+        BaremetalCloudAgent agent = computer.getNode();
+        if (agent != null) {
+            if (computer.countBusy() <= 1 && !computer.isAcceptingTasks()) {
+                LOGGER.info("Agent " + agent.getInstanceId() + " is terminated due to maxTotalUses ("
+                        + agent.maxTotalUses + ")");
+                try {
+                    agent.terminate();
+                } catch (InterruptedException | IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to terminate agent " + agent.getInstanceId(), e);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudTemplateMonitor.java
+++ b/src/main/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudTemplateMonitor.java
@@ -136,7 +136,8 @@ public class BaremetalCloudTemplateMonitor extends AsyncPeriodicWork{
                 oldTemplate.getMemoryInGBs(),
                 oldTemplate.getDoNotDisable(),
                 oldTemplate.retryTimeoutMins,
-                oldTemplate.disableLegacyImdsEndpoint
+                oldTemplate.disableLegacyImdsEndpoint,
+                oldTemplate.maxTotalUses
         );
 
     }

--- a/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate/config.jelly
+++ b/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate/config.jelly
@@ -173,6 +173,10 @@
         <f:checkbox default='false'/>
       </f:entry>
 
+      <f:entry title="${%maxTotalUses}" field="maxTotalUses">
+        <f:textbox default="-1"/>
+      </f:entry>
+
     </f:advanced>
 
     <f:entry title="">

--- a/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate/config.properties
+++ b/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate/config.properties
@@ -43,3 +43,4 @@ retryTimeoutMinutes= Template retry Timeout
 sshVerificationStrategy= Employ knownHost verification.
 bootVolumeVPUs=Boot Volume VPUs
 disableLegacyImdsEndpoint=Disable Legacy IMDS Endpoint
+maxTotalUses=Maximum Total Uses

--- a/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate/help-maxTotalUses.html
+++ b/src/main/resources/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentTemplate/help-maxTotalUses.html
@@ -1,0 +1,6 @@
+<div>
+  Maximum number of builds this agent will run before being terminated.
+  Use <code>-1</code> (or any value &lt;= 0) for unlimited builds.
+  Once the limit is reached, the agent stops accepting new builds and is
+  terminated after its current build completes.
+</div>

--- a/src/test/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentUnitTest.java
+++ b/src/test/java/com/oracle/cloud/baremetal/jenkins/BaremetalCloudAgentUnitTest.java
@@ -13,7 +13,6 @@ import com.oracle.bmc.core.model.Instance;
 import com.oracle.cloud.baremetal.jenkins.client.BaremetalCloudClient;
 
 import hudson.model.TaskListener;
-import hudson.slaves.RetentionStrategy.Always;
 
 public class BaremetalCloudAgentUnitTest {
     @Rule
@@ -121,8 +120,8 @@ public class BaremetalCloudAgentUnitTest {
         Assert.assertTrue(method.invoke(null, "42") instanceof BaremetalCloudRetentionStrategy);
         Assert.assertTrue(method.invoke(null, "1") instanceof BaremetalCloudRetentionStrategy);
         Assert.assertTrue(method.invoke(null, "-1") instanceof BaremetalCloudRetentionStrategy);
-        Assert.assertTrue(method.invoke(null, "") instanceof Always);
-        Assert.assertTrue(method.invoke(null, "   ") instanceof Always);
-        Assert.assertTrue(method.invoke(null, "0") instanceof Always);
+        Assert.assertTrue(method.invoke(null, "") instanceof BaremetalCloudRetentionStrategy);
+        Assert.assertTrue(method.invoke(null, "   ") instanceof BaremetalCloudRetentionStrategy);
+        Assert.assertTrue(method.invoke(null, "0") instanceof BaremetalCloudRetentionStrategy);
     }
 }

--- a/src/test/java/com/oracle/cloud/baremetal/jenkins/TestBaremetalCloudAgentTemplate.java
+++ b/src/test/java/com/oracle/cloud/baremetal/jenkins/TestBaremetalCloudAgentTemplate.java
@@ -292,7 +292,8 @@ public class TestBaremetalCloudAgentTemplate extends BaremetalCloudAgentTemplate
                 builder.memoryInGBs,
                 builder.doNotDisable,
                 builder.retryTimeoutMins,
-                builder.disaleLegacyImdsEndpoint);
+                builder.disaleLegacyImdsEndpoint,
+                -1);
 
     }
 


### PR DESCRIPTION
Mirrors the EC2 plugin's maxTotalUses feature. When configured on a template, the spawned agent will accept at most that many builds before being suspended and terminated. Set to -1 (default) for unlimited.

- Add maxTotalUses field to BaremetalCloudAgentTemplate and propagate it to BaremetalCloudAgent at creation time
- Implement ExecutorListener in BaremetalCloudRetentionStrategy: decrement the counter on taskAccepted, terminate the agent on taskCompleted once the limit is drained
- Replace RetentionStrategy.Always() with BaremetalCloudRetentionStrategy for idleMinutes=0; override check() to preserve keep-forever behaviour
- Add UI field (default -1), help text, and config.properties label

<!-- Please describe your pull request here. -->

### Testing done

I installed the plugin in a controller and ran multiple jobs on a cloud with max total uses set to 0 and 1 and agents were picked up as expected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
